### PR TITLE
Feat/meetup oauth

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { HttpClientModule } from "@angular/common/http";
 import { JsonpModule } from '@angular/http';
 import { IonicStorageModule } from '@ionic/storage';
 import { Meetup } from "../providers/authentication/meetup";
+import { WebDevs } from "../providers/webdevs/webdevs";
 
 @NgModule({
     declarations: [
@@ -54,6 +55,7 @@ import { Meetup } from "../providers/authentication/meetup";
     ],
     providers: [
         Meetup,
+        WebDevs,
         StatusBar,
         SplashScreen,
         Geolocation,

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -9,7 +9,8 @@
 
             <h1 *ngIf="currentUser">{{ currentUser.name }}</h1>
             <button ion-button block outline color="light" (click)="checkIn()" *ngIf="allowedToCheckin()">Check in</button>
-            <button ion-button block outline color="light" (click)="openNextEventInBrowser(latestMeetup.link)" *ngIf="showRsvpLink()">RSVP For The Next Meetup</button>
+            <button ion-button block outline color="light" (click)="rsvp(latestMeetup.id)" *ngIf="showRsvpLink()">RSVP For The Next Meetup</button>
+            <button ion-button block outline color="danger" (click)="cancelRsvp(latestMeetup.id)" *ngIf="showCancelRsvp()">Cancel RSVP</button>
             <h3 *ngIf="checkedIn" text-wrap>You are checked in. Grab some pizza and enjoy the night!</h3>
         </ion-item>
 

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -31,6 +31,16 @@
                 </ion-row>
             </ion-grid>
         </ion-item>
+        <ion-item *ngIf="logging">
+            <ion-grid>
+                <ion-row>
+                    <ion-col col-12>
+                        Logs:
+                        <p *ngFor="let log of logs">{{log}}</p>        
+                    </ion-col>
+                </ion-row>
+            </ion-grid>
+        </ion-item>
         <attendee-list-item *ngFor="let attendee of attendees" [attendee]="attendee"></attendee-list-item>
     </ion-list>
 </ion-content>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -20,7 +20,7 @@
                         <h3>{{ latestMeetup.name }}</h3>
                     </ion-col>
                     <ion-col col-2>
-                        <p class="date">{{ formatDate(latestMeetup.local_date) }}</p>
+                        <p class="date">{{ formatDate(latestMeetup.time) }}</p>
                     </ion-col>
                 </ion-row>
                 <ion-row>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -3,7 +3,8 @@
     <ion-list scrollY="true" no-lines>
         <ion-item class="user" color="grey-dark">
             <ion-avatar item-start>
-                <img src="assets/imgs/profile.jpg">
+                <img *ngIf="!currentUser" src="assets/imgs/profile.jpg">
+                <img *ngIf="currentUser" [src]="currentUser.photo.thumb_link">
             </ion-avatar>
 
             <h1 *ngIf="auth.user">{{ auth.user.displayName }}</h1>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -7,7 +7,7 @@
                 <img *ngIf="currentUser" [src]="currentUser.photo.thumb_link">
             </ion-avatar>
 
-            <h1 *ngIf="auth.user">{{ auth.user.displayName }}</h1>
+            <h1 *ngIf="currentUser">{{ currentUser.name }}</h1>
             <button ion-button block outline color="light" (click)="checkIn()" *ngIf="allowedToCheckin()">Check in</button>
             <button ion-button block outline color="light" (click)="openNextEventInBrowser(latestMeetup.link)" *ngIf="showRsvpLink()">RSVP For The Next Meetup</button>
             <h3 *ngIf="checkedIn" text-wrap>You are checked in. Grab some pizza and enjoy the night!</h3>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -60,7 +60,7 @@ export class HomePage implements OnInit {
     }
 
     checkRsvp(){
-        if(this.latestMeetup && this.currentUser){
+        if(this.latestMeetup && this.currentUser && !this.checkedIn){
             console.log('checking meetup rsvp');
             this.meetup.checkRSVP(this.latestMeetup.id, this.currentUser.id).subscribe(
                 rsvpd => {
@@ -125,7 +125,7 @@ export class HomePage implements OnInit {
             }
         }
 
-        return false;
+        return true;
     }
 
     rsvp(eventId){
@@ -171,7 +171,7 @@ export class HomePage implements OnInit {
     }
     
     showCancelRsvp(){
-        if(this.latestMeetup && !this.allowedToCheckin() && this.rsvpd){
+        if(this.latestMeetup && !this.allowedToCheckin() && !this.checkCheckIn && this.rsvpd){
             return true;
         }
         return false;

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -126,7 +126,7 @@ export class HomePage implements OnInit {
             }
         }
 
-        return true;
+        return false;
     }
 
     rsvp(eventId){
@@ -172,7 +172,7 @@ export class HomePage implements OnInit {
     }
     
     showCancelRsvp(){
-        if(this.latestMeetup && !this.allowedToCheckin() && !this.checkCheckIn && this.rsvpd){
+        if(this.latestMeetup && !this.allowedToCheckin() && !this.checkedIn && this.rsvpd){
             return true;
         }
         return false;

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -50,13 +50,14 @@ export class HomePage implements OnInit {
         this.attendeeProvier.getAttendees().subscribe(
             attendees => this.attendees = attendees,
         );
-        this.meetup.getCurrentUserInfo().then(userData => {
-            this.currentUser = userData.json();
-            console.log('current user: ', this.currentUser);
-            this.checkRsvp();
-        }).catch(()=>{
-            console.log('error');
-        });
+        this.meetup.getCurrentUserInfo().subscribe(
+            userData => {
+                this.currentUser = userData.json();
+                console.log('current user: ', this.currentUser);
+                this.checkRsvp();
+            }, err => {
+                console.log('error');
+            });
     }
 
     checkRsvp(){

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -9,6 +9,7 @@ import { Jsonp } from '@angular/http';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import 'rxjs/add/operator/map'
 import { Storage } from '@ionic/storage';
+import { Meetup } from '../../providers/authentication/meetup';
 
 @Component({
     selector: 'page-home',
@@ -20,6 +21,7 @@ export class HomePage implements OnInit {
     items: any;
     latestMeetup: any;
     checkedIn: boolean;
+    currentUser: any;
 
     constructor(
         public navCtrl: NavController,
@@ -29,7 +31,8 @@ export class HomePage implements OnInit {
         private http:HttpClient,
         private jsonp: Jsonp,
         private storage: Storage,
-        public plt: Platform
+        public plt: Platform,
+        private meetup: Meetup
     ) {
         this.checkedIn = false;
         this.items = db.list('user').valueChanges();
@@ -44,6 +47,12 @@ export class HomePage implements OnInit {
         this.attendeeProvier.getAttendees().subscribe(
             attendees => this.attendees = attendees,
         );
+        this.meetup.getCurrentUserInfo().then(userData => {
+            this.currentUser = userData.json();
+            console.log('current user: ', this.currentUser);
+        }).catch(()=>{
+            console.log('error');
+        });
     }
 
     getLatestMeetup() {
@@ -161,6 +170,10 @@ export class HomePage implements OnInit {
     }
 
     initPushNotifications() {
+        if(this.plt.is('core') || this.plt.is('mobileweb')) {
+            return; //don't init if in browser
+        } 
+
         let notificationOpenedCallback = function(jsonData) {
             alert('notificationOpenedCallback: ' + JSON.stringify(jsonData));
         };

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -58,11 +58,10 @@ export class HomePage implements OnInit {
     }
 
     getLatestMeetup() {
-        return this.queryMeetup().subscribe(
-            data => {
-                if(data.data[0]) {
-                    this.latestMeetup = data.data[0];
-                }
+        return this.meetup.getLatestEvent().subscribe(
+            latestEvent => {
+                console.log('latestEvent: ', latestEvent);
+                this.latestMeetup = latestEvent
             },
             err => {
                 console.log(err);
@@ -80,11 +79,6 @@ export class HomePage implements OnInit {
         });
     }
 
-    queryMeetup() {
-        let url = 'https://api.meetup.com/SGF-Web-Devs/events?scroll=next_upcoming&photo-host=public&page=1&sig_id=28541422&sig=71b4eb87e5e64e8f1dd28c65cc1b01ff71dd0828&callback=JSONP_CALLBACK';
-        return this.jsonp.get(url).map(res => res.json());
-    }
-
     // uggggh. whatever - Myke
     trimDescription(description) {
         let trimSpot = description.indexOf('<p>Pizza');
@@ -99,7 +93,7 @@ export class HomePage implements OnInit {
     // Probably just need to pull moment in at some point for other features, too - Myke
     formatDate(date) {
         var d = new Date(date);
-        return d.getMonth() + '/' + d.getDate() + '/' + d.getFullYear().toString().replace('20', '');
+        return d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear().toString().replace('20', '');
     }
 
     isCheckinTime(date) {
@@ -121,7 +115,7 @@ export class HomePage implements OnInit {
     }
 
     allowedToCheckin() {
-        if(this.latestMeetup && this.isCheckinTime(this.latestMeetup.local_date) && !this.checkedIn) {
+        if(this.latestMeetup && this.isCheckinTime(this.latestMeetup.time) && !this.checkedIn) {
             return true;
         }
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -10,6 +10,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import 'rxjs/add/operator/map'
 import { Storage } from '@ionic/storage';
 import { Meetup } from '../../providers/authentication/meetup';
+import { WebDevs } from '../../providers/webdevs/webdevs';
 
 @Component({
     selector: 'page-home',
@@ -32,7 +33,8 @@ export class HomePage implements OnInit {
         private jsonp: Jsonp,
         private storage: Storage,
         public plt: Platform,
-        private meetup: Meetup
+        private meetup: Meetup,
+        private webdevs: WebDevs
     ) {
         this.checkedIn = false;
         this.items = db.list('user').valueChanges();
@@ -69,14 +71,14 @@ export class HomePage implements OnInit {
     }
 
     checkIn(){
-        this.checkinCall().subscribe(goodCheckIn => {
+        this.webdevs.checkin(this.currentUser).subscribe(goodCheckIn => {
+            console.log('check response:', goodCheckIn);
             if(goodCheckIn) {
                 this.checkedIn = true;
                 this.cacheCheckin();
             }
         });
     }
-
 
     queryMeetup() {
         let url = 'https://api.meetup.com/SGF-Web-Devs/events?scroll=next_upcoming&photo-host=public&page=1&sig_id=28541422&sig=71b4eb87e5e64e8f1dd28c65cc1b01ff71dd0828&callback=JSONP_CALLBACK';
@@ -116,17 +118,6 @@ export class HomePage implements OnInit {
 
     openNextEventInBrowser(url) {
         window.open(url);
-    }
-
-    checkinCall() {
-        const httpOptions = {
-            headers: new HttpHeaders({
-                'Content-Type': 'application/json'
-            })
-        };
-
-        return this.http.post('http://demo9029555.mockable.io/checkin', { 'value1': 'yep' }, httpOptions).map((res: Response) => res);
-        //return this.http.post('http://sgf-web-devs-staging.glitchedmob.com/api/checkin', { 'value1': 'yep' }, httpOptions).map((res: Response) => res);
     }
 
     allowedToCheckin() {

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -99,15 +99,16 @@ export class HomePage implements OnInit {
     isCheckinTime(date) {
         let today = new Date();
         let meetupDate = new Date(date);
+        let checkinClose = meetupDate.getHours() + 4;
+        let checkinOpen = meetupDate.getHours() - 1;
 
         if(today.getDay() == meetupDate.getDay() && today.getMonth() == meetupDate.getMonth()) {
-            if(today.getHours() >= 17 && today.getHours() <= 20) {
+            if(today.getHours() >= checkinOpen && today.getHours() <= checkinClose) {
                 return true;
             }
         }
 
-        //return false;
-        return true;
+        return false;
     }
 
     openNextEventInBrowser(url) {

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -24,6 +24,8 @@ export class HomePage implements OnInit {
     checkedIn: boolean;
     currentUser: any;
     rsvpd: boolean;
+    logs: string[];
+    logging: boolean;
 
     constructor(
         public navCtrl: NavController,
@@ -37,6 +39,8 @@ export class HomePage implements OnInit {
         private meetup: Meetup,
         private webdevs: WebDevs
     ) {
+        this.logs = [];
+        this.logging = false;
         this.checkedIn = false;
         this.items = db.list('user').valueChanges();
 
@@ -45,6 +49,13 @@ export class HomePage implements OnInit {
         this.initPushNotifications();
     }
 
+    log(message, obj={}){
+        if(this.logging){
+            this.logs.push(`${message}: ${JSON.stringify(obj)}`);
+        }
+
+        console.log(message, obj);
+    }
 
     ngOnInit() {
         this.attendeeProvier.getAttendees().subscribe(
@@ -53,23 +64,23 @@ export class HomePage implements OnInit {
         this.meetup.getCurrentUserInfo().subscribe(
             userData => {
                 this.currentUser = userData.json();
-                console.log('current user: ', this.currentUser);
+                this.log('current user: ', this.currentUser);
                 this.checkRsvp();
             }, err => {
-                console.log('error');
+                this.log('error getting User info', err);
             });
     }
 
     checkRsvp(){
         if(this.latestMeetup && this.currentUser && !this.checkedIn){
-            console.log('checking meetup rsvp');
+            this.log('checking meetup rsvp');
             this.meetup.checkRSVP(this.latestMeetup.id, this.currentUser.id).subscribe(
                 rsvpd => {
                     this.rsvpd = rsvpd;
-                    console.log('rsvp:', rsvpd);
+                    this.log('rsvp:', rsvpd);
                 },
                 err => {
-                    console.log('failed to determine rsvp');
+                    this.log('error determining rsvp', err);
                 }
             )
         }
@@ -77,19 +88,19 @@ export class HomePage implements OnInit {
     getLatestMeetup() {
         return this.meetup.getLatestEvent().subscribe(
             latestEvent => {
-                console.log('latestEvent: ', latestEvent);
+                this.log('latestEvent: ', latestEvent);
                 this.latestMeetup = latestEvent
                 this.checkRsvp();
             },
             err => {
-                console.log(err);
+                this.log('error getting latest meetup info', err);
             }
         );
     }
 
     checkIn(){
         this.webdevs.checkin(this.currentUser).subscribe(goodCheckIn => {
-            console.log('check response:', goodCheckIn);
+            this.log('check response:', goodCheckIn);
             if(goodCheckIn) {
                 this.checkedIn = true;
                 this.cacheCheckin();
@@ -135,7 +146,7 @@ export class HomePage implements OnInit {
                 this.rsvpd = true;
             },
             err => {
-                console.log('failed to rsvp');
+                this.log('error rsvping', err);
             }
         );
     }
@@ -146,7 +157,7 @@ export class HomePage implements OnInit {
                 this.rsvpd = false;
             },
             err => {
-                console.log('failed to cancel rsvp');
+                this.log('error cancelling rsvp', err);
             }
         );
     }

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -25,6 +25,11 @@
         <div class="cta">
             <img src="assets/imgs/github-button.svg" alt="Login" (click)="login()">
         </div>
+        <div class="cta" *ngIf="!isApp">
+            <label for="token_override" style="color: white;">Token:</label>
+            <input id="token_override" type="text" [(ngModel)]="token"/>
+            <button ion-button (click)="loginOverride()">Go</button>
+        </div>
 
         <footer>
             Web Dev Community in Springfield, MO

--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -29,6 +29,7 @@
             <label for="token_override" style="color: white;">Token:</label>
             <input id="token_override" type="text" [(ngModel)]="token"/>
             <button ion-button (click)="loginOverride()">Go</button>
+            <button ion-button full color="danger" (click)="clearLocal()">Clear Cache</button>
         </div>
 
         <footer>

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -69,6 +69,11 @@ export class LoginPage implements OnInit {
             this.navCtrl.setRoot(HomePage);
         });
     }
+
+    clearLocal(){
+        this.storage.clear();
+    }
+
     login(){
         if(this.isApp){
             this.meetup.login().then((success) => {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -65,7 +65,7 @@ export class LoginPage implements OnInit {
     }
 
     loginOverride(){
-        this.meetup.tokenOverride(this.token).then(()=>{
+        this.meetup.browserTokenOverride(this.token).then(()=>{
             this.navCtrl.setRoot(HomePage);
         });
     }
@@ -77,7 +77,7 @@ export class LoginPage implements OnInit {
                 console.log(err);
             })
         } else {
-            this.meetup.getTokenFromBrowser();
+            this.meetup.browserLogin();
         }
 
         //this.auth.login();

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -21,7 +21,8 @@ import { Meetup } from "../../providers/authentication/meetup";
 })
 export class LoginPage implements OnInit {
     loginChange: any;
-
+    isApp: boolean;
+    token: string;
 
     constructor(
         public navCtrl: NavController,
@@ -55,14 +56,29 @@ export class LoginPage implements OnInit {
 
     ionViewDidLoad() {
         console.log('ionViewDidLoad LoginPage');
+
+        if(this.plt.is('core') || this.plt.is('mobileweb')) {
+            this.isApp = false;
+        } else {
+            this.isApp = true;
+        }
     }
 
-    login(){
-        this.meetup.login().then((success) => {
+    loginOverride(){
+        this.meetup.tokenOverride(this.token).then(()=>{
             this.navCtrl.setRoot(HomePage);
-        }, (err) => {
-            console.log(err);
-        })
+        });
+    }
+    login(){
+        if(this.isApp){
+            this.meetup.login().then((success) => {
+                this.navCtrl.setRoot(HomePage);
+            }, (err) => {
+                console.log(err);
+            })
+        } else {
+            this.meetup.getTokenFromBrowser();
+        }
 
         //this.auth.login();
 

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -36,11 +36,11 @@ export class LoginPage implements OnInit {
     }
 
     ngOnInit() {
-        this.storage.get('user').then((user) => {
-            if(user) {
-                this.navCtrl.push(HomePage);
-            }
-        });
+        // this.storage.get('user').then((user) => {
+        //     if(user) {
+        //         this.navCtrl.push(HomePage);
+        //     }
+        // });
 
         // this.loginChange = this.auth.getLoginChangeEmitter()
         //     .subscribe(user => this.onLoginChange(user));

--- a/src/providers/authentication/meetup.ts
+++ b/src/providers/authentication/meetup.ts
@@ -46,7 +46,7 @@ export class Meetup {
     getCurrentUserInfo(){
         let headers = new Headers();
         let memberV3Url = `${this.baseUrl}/members/self/?access_token=${this.accessToken}`;
-        return this.http.get(memberV3Url, { headers: headers }).toPromise();        
+        return this.http.get(memberV3Url, { headers: headers }).map(res=>res);        
     }
 
     rsvp(eventId, response){

--- a/src/providers/authentication/meetup.ts
+++ b/src/providers/authentication/meetup.ts
@@ -49,6 +49,22 @@ export class Meetup {
         return this.http.get(memberV3Url, { headers: headers }).toPromise();        
     }
 
+    getLatestEvent(){
+        let headers = new Headers();
+        let eventsV3Url = `${this.baseUrl}/SGF-Web-Devs/events?scroll=recent_past&access_token=${this.accessToken}`;
+        return this.http.get(eventsV3Url, {headers: headers}).map(res => {
+            let events = res.json();
+            console.log('events:', events);
+            for(let event of events){
+                if(event.status != 'past'){
+                    return event;
+                }
+            }
+            
+            return events[0];
+        });
+    }
+
     browserTokenOverride(token: string){
         return new Promise((resolve,reject) => {
             if(token && token.length > 0){

--- a/src/providers/authentication/meetup.ts
+++ b/src/providers/authentication/meetup.ts
@@ -15,6 +15,7 @@ export class Meetup {
     browserClientId: any;
     browserRedirectURI: any;
     browserUrl: any;
+    baseUrl: string;
 
     constructor(public http: Http, public iab: InAppBrowser) {
         //OAuth
@@ -26,7 +27,8 @@ export class Meetup {
         this.browserClientId = 'c6rhrufurnhhfl3e7nirenh9nl';
         this.browserRedirectURI = 'http://localhost:8100';
         this.browserUrl = 'https://secure.meetup.com/oauth2/authorize?client_id=' + this.browserClientId + '&response_type=token&redirect_uri=' + this.browserRedirectURI;
-        
+
+        this.baseUrl = 'https://api.meetup.com';
     }
 
     setAccessToken(token) {
@@ -38,14 +40,13 @@ export class Meetup {
 
         headers.append('Authorization', 'Bearer ' + this.accessToken);
         headers.append('Content-Type', 'application/json');
-        headers.append('Origin', 'http://localhost:8100');
-
-        return this.http.get('https://api.meetup.com/2/member/self/', { headers: headers }).map(res => res.json());
+        return this.http.get(`${this.baseUrl}/2/member/self/`, { headers: headers }).map(res => res.json());
     }
 
     getCurrentUserInfo(){
         let headers = new Headers();
-        return this.http.get('https://api.meetup.com/members/self/?access_token=' + this.accessToken, { headers: headers }).toPromise();        
+        let memberV3Url = `${this.baseUrl}/members/self/?access_token=${this.accessToken}`;
+        return this.http.get(memberV3Url, { headers: headers }).toPromise();        
     }
 
     browserTokenOverride(token: string){

--- a/src/providers/authentication/meetup.ts
+++ b/src/providers/authentication/meetup.ts
@@ -12,13 +12,21 @@ export class Meetup {
     clientId: any;
     redirectURI: any;
     url: any;
+    browserClientId: any;
+    browserRedirectURI: any;
+    browserUrl: any;
 
     constructor(public http: Http, public iab: InAppBrowser) {
-
         //OAuth
         this.clientId = 'mabrcd406k0hhhe6gms84lfaq0';
         this.redirectURI = 'http://localhost';
         this.url = 'https://secure.meetup.com/oauth2/authorize?client_id=' + this.clientId + '&response_type=token&redirect_uri=' + this.redirectURI;
+
+        //Need these for running locally with only a web browser on port 8100
+        this.browserClientId = 'c6rhrufurnhhfl3e7nirenh9nl';
+        this.browserRedirectURI = 'http://localhost:8100';
+        this.browserUrl = 'https://secure.meetup.com/oauth2/authorize?client_id=' + this.browserClientId + '&response_type=token&redirect_uri=' + this.browserRedirectURI;
+        
     }
 
     setAccessToken(token) {
@@ -34,12 +42,13 @@ export class Meetup {
 
         return this.http.get('https://api.meetup.com/2/member/self/', { headers: headers }).map(res => res.json());
     }
+
     getCurrentUserInfo(){
         let headers = new Headers();
-        return this.http.get('https://api.meetup.com/members/self/?access_token=' + this.accessToken, { headers: headers }).toPromise();
-        
+        return this.http.get('https://api.meetup.com/members/self/?access_token=' + this.accessToken, { headers: headers }).toPromise();        
     }
-    tokenOverride(token: string){
+
+    browserTokenOverride(token: string){
         return new Promise((resolve,reject) => {
             if(token && token.length > 0){
                 this.accessToken = token;
@@ -50,8 +59,8 @@ export class Meetup {
         });
     }
 
-    getTokenFromBrowser(){
-        this.iab.create(this.url, '_blank');
+    browserLogin(){
+        this.iab.create(this.browserUrl, '_blank');
     }
 
     login() {

--- a/src/providers/authentication/meetup.ts
+++ b/src/providers/authentication/meetup.ts
@@ -21,12 +21,12 @@ export class Meetup {
         //OAuth
         this.clientId = 'mabrcd406k0hhhe6gms84lfaq0';
         this.redirectURI = 'http://localhost';
-        this.url = 'https://secure.meetup.com/oauth2/authorize?client_id=' + this.clientId + '&response_type=token&redirect_uri=' + this.redirectURI;
+        this.url = 'https://secure.meetup.com/oauth2/authorize?scope=rsvp&client_id=' + this.clientId + '&response_type=token&redirect_uri=' + this.redirectURI;
 
         //Need these for running locally with only a web browser on port 8100
         this.browserClientId = 'c6rhrufurnhhfl3e7nirenh9nl';
         this.browserRedirectURI = 'http://localhost:8100';
-        this.browserUrl = 'https://secure.meetup.com/oauth2/authorize?client_id=' + this.browserClientId + '&response_type=token&redirect_uri=' + this.browserRedirectURI;
+        this.browserUrl = 'https://secure.meetup.com/oauth2/authorize?scope=rsvp&client_id=' + this.browserClientId + '&response_type=token&redirect_uri=' + this.browserRedirectURI;
 
         this.baseUrl = 'https://api.meetup.com';
     }
@@ -49,6 +49,29 @@ export class Meetup {
         return this.http.get(memberV3Url, { headers: headers }).toPromise();        
     }
 
+    rsvp(eventId, response){
+        let headers = new Headers();
+        let rsvpV3Url = `${this.baseUrl}/SGF-Web-Devs/events/${eventId}/rsvps?response=${response}&access_token=${this.accessToken}`;
+
+        let payload = { response }
+        return this.http.post(rsvpV3Url, payload, {headers: headers}).map(res => {
+            return res;
+        });
+    }
+    checkRSVP(eventId, userId){
+        let headers = new Headers();
+        let rsvpV3Url = `${this.baseUrl}/SGF-Web-Devs/events/${eventId}/rsvps?&access_token=${this.accessToken}`;
+        console.log('checking rsvp for ', eventId);
+        return this.http.get(rsvpV3Url, {headers: headers}).map(res => {
+            let rsvps = res.json();
+            for(let rsvp of rsvps){
+                if(rsvp.member.id === userId){
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
     getLatestEvent(){
         let headers = new Headers();
         let eventsV3Url = `${this.baseUrl}/SGF-Web-Devs/events?scroll=recent_past&access_token=${this.accessToken}`;

--- a/src/providers/webdevs/webdevs.ts
+++ b/src/providers/webdevs/webdevs.ts
@@ -1,0 +1,25 @@
+import { Injectable } from "@angular/core";
+import { Http, Headers } from "@angular/http";
+import { InAppBrowser } from "@ionic-native/in-app-browser";
+import { Observable } from "rxjs/Observable";
+import 'rxjs/add/operator/map';
+
+@Injectable()
+export class WebDevs {
+    baseUrl: any;
+    checkinPath: any;
+ 
+    constructor(public http: Http) {
+        //this.baseUrl = 'http://sgf-web-devs-staging.glitchedmob.com';       
+        //this.checkinPath = 'api/checkin
+        this.baseUrl = 'http://demo9029555.mockable.io';
+        this.checkinPath = 'checkin';
+    }
+
+    checkin(userData){
+        let headers = new Headers({
+                'Content-Type': 'application/json'
+        });
+        return this.http.post(`${this.baseUrl}/${this.checkinPath}`, userData, {headers: headers}).map(res => res.json());
+    }
+}


### PR DESCRIPTION
David,

I wanted to start leveraging the meetup APIs and was having issues when working purely in a browser because the base url is localhost:8100 (i'm guessing on device it's just localhost).  So I added an oauth consumer (which has a different clientId) that allows requests from http://localhost:8100.  It appears to work and would like to incorporate the workflow into this feature branch before you go much further so I don't have a painful rebase.  

If you want to wait until you're finished and ignore this pull request, that's fine too.  

Workflow:
1. ionic serve (launches a browser pointed to localhost:8100)
2. click "login with github"
3. takes you to meetup login, once you login, it redirects you back to localhost:8100
4. manually copy the token out of the browser url and put in the "Token:" input, click "Go"
5. takes you to the home page and resolves user picture and name
